### PR TITLE
JDO-778: remove two overloaded methods to JDOQLTypedQuery to create a…

### DIFF
--- a/src/main/java/javax/jdo/JDOQLTypedQuery.java
+++ b/src/main/java/javax/jdo/JDOQLTypedQuery.java
@@ -352,29 +352,6 @@ public interface JDOQLTypedQuery<T> extends Serializable, Closeable {
     <E> JDOQLTypedSubquery<E> subquery(CollectionExpression<Collection<E>, E> candidateCollection, Class<E> candidate, String candidateAlias);
 
     /**
-     * Method to return a correlated subquery for use in this query.
-     * The candidate collection of the subquery is defined using a list relationship of the outer query.
-     * To obtain the expression for the subquery to link it back to this query, call "result(...)" on the subquery.
-     * @param candidateList Expression defining the candidate list for the subquery
-     * @param candidateAlias Alias for the candidate
-     * @return The subquery
-     * @param <E> Candidate type for subquery
-     */
-    <E> JDOQLTypedSubquery<E> subquery(ListExpression<List<E>, E> candidateList, Class<E> candidate, String candidateAlias);
-
-    /**
-     * Method to return a correlated subquery for use in this query.
-     * The candidate collection of the subquery is defined using a map relationship of the outer query.
-     * To obtain the expression for the subquery to link it back to this query, call "result(...)" on the subquery.
-     * @param candidateMap Expression defining the candidate map for the subquery
-     * @param candidateAlias Alias for the candidate
-     * @return The subquery
-     * @param <K> The key type of the map relationship
-     * @param <V> The value type the map relationship
-     */
-    <K, V> JDOQLTypedSubquery<Map.Entry<K, V>> subquery(MapExpression<Map<K, V>, K, V> candidateMap, Class<Map.Entry<K, V>> candidate, String candidateAlias);
-
-    /**
      * Method to set the named parameters on this query prior to execution.
      * All parameter values specified in this method will only be retained until the subsequent query execution.
      * @param namedParamMap The map of parameter values keyed by their names.


### PR DESCRIPTION
… correlated subquery

Proposal by JDO conference call Jan 2, 2020: remove the two subquery methods taking a ListExpression and taking a MapExpression as argument. 